### PR TITLE
Use /addon_config instead of /config for the default location of conf-dir

### DIFF
--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -5,8 +5,23 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
+## [1.1.0] - 2023-11-26
+  
+Use "/addon_config" instead of "/config" as the default location of Transmission's config-dir.
 
-## [1.0.0] - 2023-11-26
+This change is the result of the recent Home Assistant changes published here: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/
+
+### Breaking Changes
+If you upgrade from v1.0.0 then you need to change the config-dir in the addon configuration from the old
+default value 
+
+### changes
+1. This addon no longer has access to the "/config" folder. Use "/addon_config" instead
+2. Minimum version of Home Assistant for this addon is "2023.11.3".
+
+  
+
+## [1.0.0] - 2023-11-25
   
 Initial release, with Transmission v4.0.4
 

--- a/transmission/DOCS.md
+++ b/transmission/DOCS.md
@@ -16,7 +16,7 @@ Like other addons:
 
 ### Configuration directory (aka `config-dir``)
 
-In the add-on **Configuration** tab you can specify the *config-dir*. Default=**/config/transmission**
+In the add-on **Configuration** tab you can specify the *config-dir*. Default=**/addon_config/transmission**
 
 The config-dir contains files and subdirectories that are used as the "database" of Transmission.  Transmission reads this folder content on startup and saves it on shutdown.
 

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -1,7 +1,8 @@
 name: "Transmission"
+homeassistant: "2023.11.3"
 description: "Transmission is a popular, fast, open-sourced BitTorrent client with an easy to use web UI."
 url: "https://github.com/maorcc/hassio-addon-transmission/tree/main/transmission"
-version: "1.0.0"
+version: "1.1.0"
 slug: "transmission"
 init: false
 arch:
@@ -14,7 +15,7 @@ ingress: true
 ingress_entry: transmission/web/
 ingress_port: 9091
 map:
-  - config:rw
+  - addon_config:rw
   - media:rw
   - share:rw
 ports:
@@ -22,7 +23,7 @@ ports:
   51413/tcp: 51413
   51413/udp: 51413
 options:
-  config_dir: /config/transmission
+  config_dir: /addon_config/transmission
 schema:
   config_dir: str
 # image: "ghcr.io/maorcc/{arch}-hassio-addon-transmission"


### PR DESCRIPTION
Use "/addon_config" instead of "/config" as the default location of Transmission's config-dir.

This change is the result of the recent Home Assistant changes published here: https://developers.home-assistant.io/blog/2023/11/06/public-addon-config/

### Breaking Changes
If you upgrade from v1.0.0 then you need to change the config-dir in the addon configuration from the old
default value 

### changes
1. This addon no longer has access to the "/config" folder. Use "/addon_config" instead
2. The minimum version of Home Assistant for this addon is "2023.11.3".
