### PR TITLE
Remove the option to configure the config-dir

### DIFF
--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
+ 
+## [1.2.0] - 2023-11-26
+  
+Removed the option to configure the Transmission config-dir. This parameter is now hard coded to be the new
+`addon_config` folder. 
+
+### Breaking Changes
+If you upgrade from a previous version, you may need to copy your old configuration from its previous location.  
+By default the location was at `/config/transmission`
+
+### changes
+There is no option to change the config-dir anymore.
+
+
 ## [1.1.0] - 2023-11-26
   
 Use "/addon_config" instead of "/config" as the default location of Transmission's config-dir.

--- a/transmission/DOCS.md
+++ b/transmission/DOCS.md
@@ -5,6 +5,7 @@
 Like other addons:
 
 1. Add this repository to your Add-on Store using the link below. (Or manually add the repository `https://github.com/maorcc/hassio-addon-transmission` to your Home Assistant add-ons repositories list.)
+
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmaorcc%2Fhassio-addon-transmission)
 
 2. Find the "Transmission" add-on in the Home Assistant Add-on Store. Click on it, and click on the "INSTALL" button.
@@ -14,19 +15,9 @@ Like other addons:
 
 ## Configuration
 
-### Configuration directory (aka `config-dir``)
-
-In the add-on **Configuration** tab you can specify the *config-dir*. Default=**/addon_config/transmission**
-
-The config-dir contains files and subdirectories that are used as the "database" of Transmission.  Transmission reads this folder content on startup and saves it on shutdown.
-
-If the config-dir is empty or does not exist, the add-on will create it and fill it with its default settings.
-
-You can change the config-dir folder location in the add-on configuration page.  But if you change it after running the add-on, your settings will not automatically move from the old to the new location.  If you want your old configuration then you need to copy the relevant files manually.
-
 ### The Settings.json file
 
-The Transmission settings are stored in the `settings.json` file that is located in the config-dir.
+The Transmission settings are stored in the `settings.json` file that is located in the addon_config directory.
 
 Two ways to change Transmission settings:
 

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -22,8 +22,5 @@ ports:
   9091/tcp: null
   51413/tcp: 51413
   51413/udp: 51413
-options:
-  config_dir: /addon_config/transmission
-schema:
-  config_dir: str
+
 # image: "ghcr.io/maorcc/{arch}-hassio-addon-transmission"

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -2,7 +2,7 @@ name: "Transmission"
 homeassistant: "2023.11.3"
 description: "Transmission is a popular, fast, open-sourced BitTorrent client with an easy to use web UI."
 url: "https://github.com/maorcc/hassio-addon-transmission/tree/main/transmission"
-version: "1.1.0"
+version: "1.2.0"
 slug: "transmission"
 init: false
 arch:

--- a/transmission/run.sh
+++ b/transmission/run.sh
@@ -1,13 +1,11 @@
 #!/usr/bin/with-contenv bashio
 
-readonly config_dir="$(bashio::config 'config_dir')"
+readonly config_dir="/config"
 readonly settings_file="$config_dir/settings.json"
 
-bashio::log.info "Transmission configuration direcotry: $config_dir"
 if ! bashio::fs.file_exists "$settings_file"; then
-    bashio::log.info 'First run! Initializing configuration.'
+    bashio::log.info 'First run! Initializing Transmission settings.json in the addon_configs folder.'
 
-    mkdir -p "$config_dir"
     cat > "$settings_file" <<'EOF'
 {
     "rpc-whitelist": "172.30.32.2",

--- a/transmission/translations/en.yaml
+++ b/transmission/translations/en.yaml
@@ -1,12 +1,4 @@
 ---
-configuration:
-  config_dir:
-    name: Transmission Configuration Directory (aka config-dir)
-    description: >
-      Where transmission puts its settings.json and other configuration files.  
-      When changed, you may need to manually copy any configuration you already 
-      have from a previous configuration directory. 
-      Default: /share/Transmission
 network:
   9091/tcp: >
     Transmission WebUI and RPC port. 
@@ -16,4 +8,5 @@ network:
   51413/tcp: >
     Peer Port TCP.  
     Recommend value is 51413.  May not contribute to torrents download speed if changed.
-  51413/udp: Peer Port UDP.  Must be identical to the "Peer Port TCP" above.
+  51413/udp: >
+    Peer Port UDP.  Must be identical to the "Peer Port TCP" above.


### PR DESCRIPTION
Removed the option to configure the Transmission config-dir. This parameter is now hard-coded to be the new
`addon_config` folder. 

### Breaking Changes
If you upgrade from a previous version, you may need to copy your old configuration from its previous location.  
By default, the location was at `/config/transmission`

### changes
There is no option to change the config-dir anymore.