### PR TITLE
Use docker image

### DIFF
--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -100,8 +100,7 @@ jobs:
 
       - name: Build ${{ matrix.addon }} add-on
         if: steps.check.outputs.build_arch == 'true'
-#        uses: home-assistant/builder@2023.09.0
-        uses: maduxa/builder@master
+        uses: home-assistant/builder@2023.09.0
         with:
           args: |
             ${{ env.BUILD_ARGS }} \

--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -5,7 +5,15 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
- 
+
+## [1.2.3] - 2023-11-27
+  
+Use docker images for faster and more reliable installations of this addon.
+
+### changes
+None.
+
+
 ## [1.2.0] - 2023-11-26
   
 Removed the option to configure the Transmission config-dir. This parameter is now hard coded to be the new

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -2,7 +2,7 @@ name: "Transmission"
 homeassistant: "2023.11.3"
 description: "Transmission is a popular, fast, open-sourced BitTorrent client with an easy to use web UI."
 url: "https://github.com/maorcc/hassio-addon-transmission/tree/main/transmission"
-version: "1.2.2"
+version: "1.2.3"
 slug: "transmission"
 init: false
 arch:
@@ -22,5 +22,4 @@ ports:
   9091/tcp: null
   51413/tcp: 51413
   51413/udp: 51413
-
-# image: "ghcr.io/maorcc/{arch}-hassio-addon-transmission"
+image: "ghcr.io/maorcc/{arch}-hassio-addon-transmission"


### PR DESCRIPTION
At last, I've fixed the issue that docker images were not created on the GitHub registry. The issue was in the GitHub repository settings.

Needed to adjust the github Actions configuration (Settings > Actions > General > Workflow > Read & Write)