### PR TITLE
Upgrade Alpine to 3.24 and Transmission to 4.1.2

### DIFF
--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
+## [1.3.0] - 2026-06-23
+
+Bump Alpine base from 3.22 to 3.24 and Transmission from 4.0.6 to 4.1.2.
+
 ## [1.2.9] - 2026-02-11
 
 Bump Alpine base from 3.21 to 3.23 and Transmission from 4.0.6-r0 to 4.0.6-r4.

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -2,7 +2,7 @@ ARG BUILD_FROM
 FROM $BUILD_FROM
 
 RUN apk add --no-cache \
-  transmission-daemon~=4.0.6-r4
+  transmission-daemon~=4.1.2-r0
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/transmission/build.yaml
+++ b/transmission/build.yaml
@@ -1,3 +1,3 @@
 build_from:
-  aarch64: "ghcr.io/home-assistant/aarch64-base:3.22"
-  amd64: "ghcr.io/home-assistant/amd64-base:3.22"
+  aarch64: "ghcr.io/home-assistant/aarch64-base:3.24"
+  amd64: "ghcr.io/home-assistant/amd64-base:3.24"

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -2,7 +2,7 @@ name: "Transmission"
 homeassistant: "2023.11.3"
 description: "Transmission is a popular, fast, open-sourced BitTorrent client with an easy to use web UI."
 url: "https://github.com/maorcc/hassio-addon-transmission/tree/main/transmission"
-version: "1.2.9"
+version: "1.3.0"
 slug: "transmission"
 init: false
 arch:


### PR DESCRIPTION
## Summary

- Bump Alpine base images from 3.22 to 3.24 (latest stable, released 2026-06-09)
- Upgrade transmission-daemon from 4.0.6-r4 to 4.1.2-r0
- Bump addon version 1.2.9 to 1.3.0

## Notes

A previous attempt to upgrade to Alpine 3.23 was reverted because the aarch64 base image wasn't published. Both aarch64 and amd64 base images for 3.24 are confirmed available on ghcr.io. The deprecated architectures (armhf, armv7, i386) were dropped in a prior release, so this is no longer a concern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Released version 1.3.0 of the Transmission addon
  * Updated Transmission daemon to version 4.1.2
  * Upgraded Alpine Linux base image to version 3.24

<!-- end of auto-generated comment: release notes by coderabbit.ai -->