### PR TITLE
Upgrade Alpine to 3.24 and Transmission to 4.1.2

### DIFF
--- a/transmission/CHANGELOG.md
+++ b/transmission/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
  
+## [1.3.0] - 2026-06-24
+
+Bump Alpine base from 3.23 to 3.24 and Transmission from 4.0.6 to 4.1.2.
+
 ## [1.2.9] - 2026-02-11
 
 Bump Alpine base from 3.21 to 3.23 and Transmission from 4.0.6-r0 to 4.0.6-r4.

--- a/transmission/Dockerfile
+++ b/transmission/Dockerfile
@@ -1,8 +1,8 @@
-ARG BUILD_FROM=ghcr.io/home-assistant/base:3.23
+ARG BUILD_FROM=ghcr.io/home-assistant/base:3.24
 FROM ${BUILD_FROM}
 
 RUN apk add --no-cache \
-  transmission-daemon~=4.0.6-r4
+  transmission-daemon~=4.1.2-r0
 
 COPY run.sh /
 RUN chmod a+x /run.sh

--- a/transmission/config.yaml
+++ b/transmission/config.yaml
@@ -2,7 +2,7 @@ name: "Transmission"
 homeassistant: "2023.11.3"
 description: "Transmission is a popular, fast, open-sourced BitTorrent client with an easy to use web UI."
 url: "https://github.com/maorcc/hassio-addon-transmission/tree/main/transmission"
-version: "1.2.9"
+version: "1.3.0"
 slug: "transmission"
 init: false
 arch:


### PR DESCRIPTION
## Summary

- Bump Alpine base image from 3.23 to 3.24 (`FROM ghcr.io/home-assistant/base:3.24`)
- Upgrade `transmission-daemon` from 4.0.6-r4 to 4.1.2-r0
- Bump add-on version 1.2.9 to 1.3.0

Built on top of the new composable-actions pipeline (multi-arch manifest, native runners). Replaces #63, which predated the builder migration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Bumped add-on version to 1.3.0
  * Updated Transmission to version 4.1.2
  * Updated Alpine base to version 3.24

<!-- end of auto-generated comment: release notes by coderabbit.ai -->