### PR TITLE
Document release process and HA update-cache troubleshooting in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,3 +26,39 @@ Images are built and published by `.github/workflows/builder.yaml` using the Hom
 3. Update `transmission/Dockerfile` — bump the `FROM ghcr.io/home-assistant/base:<version>` base image to the new Alpine version, and update the `transmission-daemon` package pin to the exact version (e.g. `~=4.1.2-r0`)
 4. Bump version in `transmission/config.yaml` (patch bump for same Transmission version, minor bump for new Transmission version)
 5. Add changelog entry in `transmission/CHANGELOG.md`
+
+### Releasing
+
+Merging the version bump to `main` triggers `.github/workflows/builder.yaml`, which
+builds, signs, and publishes the per-arch images plus the multi-arch manifest tagged
+with the new version and `latest`. Pull requests only run a **test build** (no push),
+so: open a PR, confirm Builder + Lint are green, then merge to `main` to publish.
+
+The manifest is published to `ghcr.io/maorcc/hassio-addon-transmission`. This GHCR
+package must stay **Public** so Home Assistant Supervisor can pull it anonymously
+(it was created Public automatically because the repo is public).
+
+### Verifying a published release
+
+Confirm the tag is published, public, and multi-arch (anonymous pull):
+
+```bash
+tok=$(curl -s "https://ghcr.io/token?scope=repository:maorcc/hassio-addon-transmission:pull&service=ghcr.io" | jq -r .token)
+curl -s -H "Authorization: Bearer $tok" -H "Accept: application/vnd.oci.image.index.v1+json" \
+  https://ghcr.io/v2/maorcc/hassio-addon-transmission/manifests/<version> \
+  | jq -c '[.manifests[] | select(.platform.os=="linux") | "\(.platform.os)/\(.platform.architecture)"]'
+# expect: ["linux/arm64","linux/amd64"]
+```
+
+### Troubleshooting: Home Assistant still shows the old version
+
+After a release, Supervisor's add-on store cache can lag — it may show "update available"
+yet report "up-to-date" on click, or keep showing the old version. Force a re-sync:
+
+```bash
+ha store reload && ha supervisor reload
+ha addons info transmission | grep -E "version|update_available"   # expect version_latest: <new>
+ha addons update transmission
+```
+
+If still stuck, restart the Supervisor (Settings → System → ⋮ → Restart Supervisor).


### PR DESCRIPTION
Adds operational notes to CLAUDE.md that came out of the builder migration and 1.3.0 release:

- **Releasing** — merging to `main` publishes (PRs only test-build); the manifest must stay Public for Supervisor to pull anonymously.
- **Verifying a published release** — anonymous GHCR pull check to confirm the tag is public and multi-arch.
- **Troubleshooting** — the Supervisor add-on store cache lag ("update available" vs "up-to-date") and how to force a re-sync.

Docs only; no code or workflow changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clearer release guidance, including what happens when changes merge to the main branch and how release builds are published.
  * Added a step-by-step verification example for checking a published release and confirming supported platforms.
  * Expanded troubleshooting steps for cases where the latest version does not appear, including cache refresh and restart guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->