### PR TITLE
Document saving downloads to a network or external drive

### DIFF
--- a/transmission/DOCS.md
+++ b/transmission/DOCS.md
@@ -44,6 +44,17 @@ The default values in settings.json are similar to the default values that are d
 3. `download-dir`="/share/download". This is where Transmission will put the files it downloads.  You can set it to any directory either under "/media" or under "/share".
 
 
+### Saving downloads to a network or external drive
+
+Transmission can save downloads to a network share (such as an SMB drive) or an external drive. The download folder must be under `/media` or `/share`, because those are the only storage locations the app is allowed to write to.
+
+1. **Mount the drive in Home Assistant.** Go to **Settings → System → Storage**, click **Add network storage**, and add your share with the **Media** (or **Share**) usage type. Once mounted, it becomes available to the app as a folder under `/media/<share-name>` (or `/share/<share-name>`).
+
+2. **Set it as the download folder.** Open the Transmission web UI, click the settings/wrench icon, choose **Edit Preferences → Torrents**, and set **"Download to"** to that path, for example `/media/<share-name>/download`. No file editing is required.
+
+New downloads will then go straight to the network or external drive.
+
+
 ## How to Use
 
 The "Transmission" easy-to-use web UI is available on the Home Assistant sidebar.


### PR DESCRIPTION
Adds a DOCS.md section explaining how to save Transmission downloads to a network share (SMB) or external drive:

- Mount the share via Home Assistant network storage (Settings → System → Storage → Add network storage), which exposes it under `/media/<share-name>` or `/share/<share-name>`.
- Set it as the download folder in the Transmission web UI under Edit Preferences → Torrents → "Download to".
- Notes the `/media` or `/share` constraint.

Addresses #43.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for saving downloads to a network or external drive.
  * Clarified where the download folder must be located and how to mount a network drive.
  * Included steps for setting the download destination from the Transmission web interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->