### PR TITLE
Use Home Assistant's new "App" terminology in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Transmission - Home Assistant add-on
+# Transmission - Home Assistant app
 
 ![Supports aarch64 Architecture][aarch64-shield]
 ![Supports amd64 Architecture][amd64-shield]
@@ -6,20 +6,20 @@
 ![Supports armv7 Architecture][armv7-shield]
 ![Supports i386 Architecture][i386-shield]
 
-This repository provides a [Transmission](https://transmissionbt.com/) add-on for [Home Assistant](https://www.home-assistant.io/).
+This repository provides a [Transmission](https://transmissionbt.com/) app for [Home Assistant](https://www.home-assistant.io/).
 
 <img src="https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission.png" width="720" height="300">
 
 
 Learn more about the Transmission BitTorrent client from the official Transmission website: https://transmissionbt.com/
 
-Read the [detailed documentation](./transmission) of this Home Assitant Transmission add-on.
+Read the [detailed documentation](./transmission) of this Home Assitant Transmission app.
 
-To install, add this repository to your Home Assistant add-ons Store by clicking here:
+To install, add this repository to your Home Assistant App Store by clicking here:
 
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmaorcc%2Fhassio-addon-transmission)
 
-More details on installing and configuring this add-on can be found in the add-on docs, [here](./transmission/).
+More details on installing and configuring this app can be found in the app docs, [here](./transmission/).
 
 If you like it, please ⭐ this github repository. Thank you! <big>🙏</big>
 
@@ -28,7 +28,7 @@ If you like it, please ⭐ this github repository. Thank you! <big>🙏</big>
 <!--
 
 Notes to developers after forking or using the github template feature:
-- While developing comment out the 'image' key from 'example/config.yaml' to make the supervisor build the addon
+- While developing comment out the 'image' key from 'example/config.yaml' to make the supervisor build the app
   - Remember to put this back when pushing up your changes.
 - When you merge to the 'main' branch of your repository a new build will be triggered.
   - Make sure you adjust the 'version' key in 'example/config.yaml' when you do that.

--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 ![Supports armv7 Architecture][armv7-shield]
 ![Supports i386 Architecture][i386-shield]
 
-This repository provides a [Transmission](https://transmissionbt.com/) app for [Home Assistant](https://www.home-assistant.io/).
+This repository provides a [Transmission](https://transmissionbt.com/) app for [Home Assistant](https://www.home-assistant.io/). (Home Assistant renamed "add-ons" to "apps" in 2026; this is the same thing previously known as the Transmission add-on.)
 
 <img src="https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/transmission.png" width="720" height="300">
 
 
 Learn more about the Transmission BitTorrent client from the official Transmission website: https://transmissionbt.com/
 
-Read the [detailed documentation](./transmission) of this Home Assitant Transmission app.
+Read the [detailed documentation](./transmission) of this Home Assistant Transmission app.
 
 To install, add this repository to your Home Assistant App Store by clicking here:
 

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-    "name": "Hass.io Add-ons by maorc",
+    "name": "Hass.io Apps by maorc",
     "url": "https://github.com/maorcc/hassio-addon-transmission",
     "maintainer": "Maor <255973+maorcc@users.noreply.github.com>"
   }

--- a/repository.json
+++ b/repository.json
@@ -1,5 +1,5 @@
 {
-    "name": "Hass.io Apps by maorc",
+    "name": "Home Assistant Apps by maorcc",
     "url": "https://github.com/maorcc/hassio-addon-transmission",
     "maintainer": "Maor <255973+maorcc@users.noreply.github.com>"
   }

--- a/transmission/DOCS.md
+++ b/transmission/DOCS.md
@@ -1,14 +1,14 @@
-# Home Assistant Add-on: Transmission
+# Home Assistant App: Transmission
 
 ## Installation
 
-Like other addons:
+Like other apps:
 
-1. Add this repository to your Add-on Store using the link below. (Or manually add the repository `https://github.com/maorcc/hassio-addon-transmission` to your Home Assistant add-ons repositories list.)
+1. Add this repository to your App Store using the link below. (Or manually add the repository `https://github.com/maorcc/hassio-addon-transmission` to your Home Assistant apps repositories list.)
 
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmaorcc%2Fhassio-addon-transmission)
 
-2. Find the "Transmission" add-on in the Home Assistant Add-on Store. Click on it, and click on the "INSTALL" button.
+2. Find the "Transmission" app in the Home Assistant App Store. Click on it, and click on the "INSTALL" button.
 
 3. Turn on the **Show in sidebar** and **Start on boot** options.
 
@@ -23,13 +23,13 @@ Two ways to change Transmission settings:
 
 1. Most Transmission settings can be modified via the Transmission web UI. (Recommended)
 
-2. Edit the settings.json file manually but only while the add-on is not running. Because on Transmission shutdown all the settings are automatically saved from memory.  (Security related settings cannot be changed in the web UI.) 
+2. Edit the settings.json file manually but only while the app is not running. Because on Transmission shutdown all the settings are automatically saved from memory.  (Security related settings cannot be changed in the web UI.) 
 
 For full documentation on Transmission settings see the [Transmission Docs].
 
 > <big>⚠️ IMPORTANT</big>
 >
-> Changes to the `settings.json` file should only be done when the add-on is stopped.  Otherwise your changes will be discarded.
+> Changes to the `settings.json` file should only be done when the app is stopped.  Otherwise your changes will be discarded.
 
 ### The default settings
 
@@ -48,11 +48,11 @@ The default values in settings.json are similar to the default values that are d
 
 The "Transmission" easy-to-use web UI is available on the Home Assistant sidebar.
 
-If you do not see it on the sidebar, make sure the addon is running and that you have turned on the "Show in sidebar" option on the Add-on page.
+If you do not see it on the sidebar, make sure the app is running and that you have turned on the "Show in sidebar" option on the App page.
 
 You will find the files you downloaded with Transmission in "/share/download" (That is unless you have changed the `download-dir` settings) 
 
-If you like this add-on, please ⭐ it on [github](https://github.com/maorcc/hassio-addon-transmission). Thank you! 🙏
+If you like this app, please ⭐ it on [github](https://github.com/maorcc/hassio-addon-transmission). Thank you! 🙏
 
 
 ## Support
@@ -67,7 +67,7 @@ You have several options to get them answered:
 
 In case you've found a bug, please [open an issue on our GitHub][issue].
 
-To check what is the latest version of Transmission that can be supported by this addon, check what is the latest [Alpine version that is supported by Home Assistant Docker-Base](https://github.com/home-assistant/docker-base/pkgs/container/aarch64-base#base-images), then check in [alpinelinux.org](https://pkgs.alpinelinux.org/packages?name=transmission&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=) what version of Transmission is supported by that Alpine.
+To check what is the latest version of Transmission that can be supported by this app, check what is the latest [Alpine version that is supported by Home Assistant Docker-Base](https://github.com/home-assistant/docker-base/pkgs/container/aarch64-base#base-images), then check in [alpinelinux.org](https://pkgs.alpinelinux.org/packages?name=transmission&branch=edge&repo=&arch=x86_64&origin=&flagged=&maintainer=) what version of Transmission is supported by that Alpine.
 
 [discord]: https://discord.gg/9H9uwXXEhJ
 [forum]: https://community.home-assistant.io

--- a/transmission/DOCS.md
+++ b/transmission/DOCS.md
@@ -1,5 +1,7 @@
 # Home Assistant App: Transmission
 
+> Note: Home Assistant renamed "Add-ons" to "Apps" (Add-on Store → App Store) in 2026. This Transmission app is the same thing previously called the Transmission add-on.
+
 ## Installation
 
 Like other apps:

--- a/transmission/README.md
+++ b/transmission/README.md
@@ -1,6 +1,6 @@
 ![Supports aarch64 Architecture][aarch64-shield] ![Supports amd64 Architecture][amd64-shield] ![Supports armhf Architecture][armhf-shield] ![Supports armv7 Architecture][armv7-shield] ![Supports i386 Architecture][i386-shield]
 
-# Transmission Add-on
+# Transmission App
 
 [Transmission](https://transmissionbt.com/) is a popular, fast, [open-sourced](https://github.com/transmission/transmission) BitTorrent client with an intuitive and easy to use web UI.
 
@@ -15,7 +15,7 @@ For more details on Transmission see: https://transmissionbt.com/
 ![Transmission Screenshot](https://transmissionbt.com/assets/images/homepage/carousel_homepage/screenshot_windows.png)
 
 ## Thank you
-If you like this add-on, please ⭐ it on [github](https://github.com/maorcc/hassio-addon-transmission). Thank you! 🙏
+If you like this app, please ⭐ it on [github](https://github.com/maorcc/hassio-addon-transmission). Thank you! 🙏
 
 [aarch64-shield]: https://img.shields.io/badge/aarch64-yes-green.svg
 [amd64-shield]: https://img.shields.io/badge/amd64-yes-green.svg


### PR DESCRIPTION
Home Assistant 2026.2 renamed **Add-ons** to **Apps** (and the **Add-on Store** to the **App Store**). This updates the user-facing prose in the documentation to match the current terminology.

Files updated:
- `README.md`
- `transmission/README.md`
- `transmission/DOCS.md`

Technical identifiers are intentionally left unchanged: the `hassio-addon-transmission` repository name/URLs, the `addon_config` directory, the Home Assistant install badge (`supervisor_add_addon_repository`), and the `ha addons` CLI commands.

The `CHANGELOG.md` (historical entries) and CI workflow files (which reference Home Assistant's own `find-addons` / linter actions) are out of scope.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated project documentation to use the newer Home Assistant “app” terminology instead of “add-on.”
  * Renamed titles and installation references to “App Store” and app docs for consistency.
  * Clarified that the Transmission app is the successor to the previously named add-on.
  * Adjusted contributor guidance and installation notes to match the updated terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->