### PR TITLE
Link README to DOCS.md with an absolute URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ This repository provides a [Transmission](https://transmissionbt.com/) app for [
 
 Learn more about the Transmission BitTorrent client from the official Transmission website: https://transmissionbt.com/
 
-Read the [detailed documentation](./transmission) of this Home Assistant Transmission app.
+Read the [detailed documentation](https://github.com/maorcc/hassio-addon-transmission/blob/main/transmission/DOCS.md) of this Home Assistant Transmission app.
 
 To install, add this repository to your Home Assistant App Store by clicking here:
 
 [![Open your Home Assistant instance and show the add add-on repository dialog with a specific repository URL pre-filled.](https://my.home-assistant.io/badges/supervisor_add_addon_repository.svg)](https://my.home-assistant.io/redirect/supervisor_add_addon_repository/?repository_url=https%3A%2F%2Fgithub.com%2Fmaorcc%2Fhassio-addon-transmission)
 
-More details on installing and configuring this app can be found in the app docs, [here](./transmission/).
+More details on installing and configuring this app can be found in the app docs, [here](https://github.com/maorcc/hassio-addon-transmission/blob/main/transmission/DOCS.md).
 
 If you like it, please ⭐ this github repository. Thank you! <big>🙏</big>
 


### PR DESCRIPTION
Points the root README's documentation links directly at `transmission/DOCS.md` so GitHub visitors can reach the detailed docs. GitHub only auto-renders a folder's `README.md` (the short intro), not `DOCS.md`, so the detailed install/config/usage content was previously unreachable from the README.

Uses an absolute `github.com` URL rather than a relative path: Home Assistant serves add-on markdown from its own host origin and does not resolve relative links the way GitHub does, so absolute is the portable choice (and matches the community `addon-example` template).

Root-`README.md`-only change, which is outside the Builder path filter, so it does not trigger a build or a user upgrade prompt.